### PR TITLE
Enabled scrolling via mouse wheel

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -315,6 +315,8 @@ void process_events()
                 break;
             }
             break;
+        case SDL_MOUSEWHEEL:
+	    gUIState.scroll += event.wheel.y;
         }
     }
 }


### PR DESCRIPTION
Now scrolling with mouse wheel works again. Since it is the only way to zoom in and out, that was quite a headache.
